### PR TITLE
Drop libkodiplatform and require libp8-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
+find_package(p8-platform REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR}
-                    ${kodiplatform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/lib/liborganya)
 
 add_subdirectory(lib/liborganya)
@@ -18,7 +18,7 @@ add_subdirectory(lib/liborganya)
 set(ORG_SOURCES src/OrganyaCodec.cpp
                 src/RingBuffer.cpp)
 
-set(DEPLIBS organya)
+set(DEPLIBS ${p8-platform_LIBRARIES} organya)
 
 build_addon(audiodecoder.organya ORG DEPLIBS)
 


### PR DESCRIPTION
No add-on bump need, I think